### PR TITLE
feat: Add service layer and expand architecture documentation to incl…

### DIFF
--- a/.cursor/rules/architecture-rules.mdc
+++ b/.cursor/rules/architecture-rules.mdc
@@ -36,3 +36,21 @@ This codebase follows a layered architecture. When implementing new features or 
     - Perform authorization checks (this belongs in Services).
     - Validate the shape/type of DTOs or domain objects passed *to it* by the Service layer. The repository assumes that data has been validated by higher layers according to business rules.
 - **Key Principle:** Repositories act as data access gateways, isolating database concerns and ensuring data conformity to defined models.
+
+## 3. The Service Layer
+
+- **Location:** `src/services/`
+- **Primary Role:** Encapsulates business logic, orchestrates data operations, and enforces application rules.
+- **Responsibilities:**
+    1. **Business Logic Implementation:** Contains core logic for all use cases and operations (e.g., creating notes, accepting share invites).
+    2. **Fine-Grained Authorization:** Performs permission checks using `UserContext` and resource-specific data. This includes checking ownership and roles (e.g., note author). An `AuthorizationService` centralizes this logic for other services.
+    3. **Business Rule Validation:** Enforces complex validation rules beyond basic data validation (e.g., email uniqueness, verification code expiration, course capacity checks).
+    4. **Data Orchestration & Integrity:** Uses repository interfaces to fetch and persist data. Manages operations requiring multiple data sources (e.g., verifying `userId` and `courseId` before creating a `Membership`).
+    5. **External Service Integration:** Manages external API calls through dedicated client modules (e.g., syncing rosters with Canvas LMS).
+    6. **Transaction Management:** Handles atomic operations across multiple database writes when native database support isn't available.
+    7. **Return Values:** Returns domain objects from `src/schemas/` or business errors that controllers map to HTTP responses.
+- **Service-to-Service Communication:**
+    - Allowed when completing user-initiated operations that require multiple services.
+    - The calling service passes `UserContext` to the called service.
+    - Called services perform task-specific authorization without repeating top-level permission checks.
+- **Key Principle:** Services act as the application's brain, managing business rules, validations, data access, and integrations.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,6 +8,7 @@ The application follows a common layered architecture pattern, consisting of the
 
 1.  **Model Layer (Zod Schemas & TypeScript Types):** Defines the structure, validation, and types for data entities.
 2.  **Data Access Layer (Interfaces and Implementations following the Repository Pattern):** Abstracts the interaction with the data store (e.g., MongoDB).
+3.  **Services Layer:** Contains the core business logic of the application.
 
 ## Layer Details
 
@@ -27,6 +28,15 @@ The application follows a common layered architecture pattern, consisting of the
   - Provide a clean API (interfaces) for CRUD (Create, Read, Update, Delete) operations and other data queries for specific entities.
   - Implementations of these interfaces handle the specific database interactions (e.g., using a MongoDB driver).
   - Ensure that the rest of the application (primarily services) is independent of the chosen database technology. Domain models use simple `id: string`, and repositories handle the mapping to/from database-specific ID formats (like MongoDB's `ObjectId`).
+
+### 3. Services Layer
+
+- **Location:** `src/services/`
+- **Responsibility:**
+  - Implement the core business logic and use cases of the application.
+  - Orchestrate operations by interacting with one or more repositories from the Data Access Layer.
+  - Perform data transformations and complex validations that are beyond simple schema checks.
+  - Decoupled from the specifics of the HTTP layer (controllers) and the database (repositories).
 
 > [!NOTE]
 > More will be added to this document as we implement the layers like Controllers, Services, etc.

--- a/src/services/note.service.ts
+++ b/src/services/note.service.ts
@@ -1,0 +1,36 @@
+import type { INoteRepository } from "@/repositories/note.repository.ts";
+import type { PaginatedResult } from "@/schemas/shared.schema.ts";
+import type {
+  CreateNoteDto,
+  Note,
+  UpdateNoteDto,
+} from "@/schemas/note.schema.ts";
+import type { QueryParams } from "@/schemas/shared.schema.ts";
+
+export class NoteService {
+  private readonly noteRepository: INoteRepository;
+
+  constructor(noteRepository: INoteRepository) {
+    this.noteRepository = noteRepository;
+  }
+
+  async getAllNotes(params: QueryParams): Promise<PaginatedResult<Note>> {
+    return this.noteRepository.findAll(params);
+  }
+
+  async getById(id: string): Promise<Note | null> {
+    return this.noteRepository.findById(id);
+  }
+
+  async create(data: CreateNoteDto): Promise<Note> {
+    return this.noteRepository.create(data);
+  }
+
+  async update(id: string, data: UpdateNoteDto): Promise<Note | null> {
+    return this.noteRepository.update(id, data);
+  }
+
+  async delete(id: string): Promise<boolean> {
+    return this.noteRepository.delete(id);
+  }
+}


### PR DESCRIPTION
This PR introduces a new Service Layer for note management and updates the corresponding architecture documentation to reflect the layered architecture pattern along with its related rules.  

- Added a NoteService in src/services/note.service.ts to encapsulate note-related business logic.  
- Expanded docs/architecture.md to include a detailed description of the Services Layer.  
- Updated .cursor/rules/architecture-rules.mdc to document the responsibilities and design principles of the Service Layer.